### PR TITLE
Adds compression prior to S3 upload, ensuring Content-Enco…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ public void ConfigureServices(IServiceCollection services)
             ServerSideEncryptionCustomerMethod = ServerSideEncryptionCustomerMethod.AES256,
             ServerSideEncryptionCustomerProvidedKey = "MyBase64Key",
             ServerSideEncryptionCustomerProvidedKeyMD5 = "MD5OfMyBase64Key",
-            ServerSideEncryptionKeyManagementServiceKeyId = "AwsKeyManagementServiceId"
+            ServerSideEncryptionKeyManagementServiceKeyId = "AwsKeyManagementServiceId",
+            // Compress stored XML before write to S3
+            Compress = true
         });
     });
 }

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/EphemeralXmlRepository.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/EphemeralXmlRepository.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed under the Apache License, Version 2.0.
+//
+// Copied verbatim as a useful testing internal implementation detail
 using Microsoft.AspNet.DataProtection.Repositories;
 using System;
 using System.Collections.Generic;

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/KmsManagerIntegrationTests.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/KmsManagerIntegrationTests.cs
@@ -3,7 +3,6 @@
 using Amazon;
 using Amazon.KeyManagementService;
 using AspNetCore.DataProtection.Aws.Kms;
-using Microsoft.AspNet.DataProtection.AuthenticatedEncryption;
 using Microsoft.AspNet.DataProtection.AuthenticatedEncryption.ConfigurationModel;
 using Microsoft.AspNet.DataProtection.KeyManagement;
 using Microsoft.AspNet.DataProtection.Repositories;
@@ -30,13 +29,41 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
         }
 
         [Fact]
+        public void ExpectFullKeyManagerExplicitAwsStoreRetrieveToSucceed()
+        {
+            var config = new KmsXmlEncryptorConfig(KmsIntegrationTests.ApplicationName, KmsIntegrationTests.KmsTestingKey);
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddDataProtection();
+            serviceCollection.ConfigureDataProtection(configure =>
+            {
+                configure.ProtectKeysWithAwsKms(kmsClient, config);
+            });
+            serviceCollection.AddInstance<IXmlRepository>(new EphemeralXmlRepository());
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var keyManager = new XmlKeyManager(serviceProvider.GetRequiredService<IXmlRepository>(),
+                                               serviceProvider.GetRequiredService<IAuthenticatedEncryptorConfiguration>(),
+                                               serviceProvider);
+
+            var activationDate = new DateTimeOffset(new DateTime(1980, 1, 1));
+            var expirationDate = new DateTimeOffset(new DateTime(1980, 6, 1));
+            keyManager.CreateNewKey(activationDate, expirationDate);
+
+            var keys = keyManager.GetAllKeys();
+
+            Assert.Equal(1, keys.Count);
+            Assert.Equal(activationDate, keys.Single().ActivationDate);
+            Assert.Equal(expirationDate, keys.Single().ExpirationDate);
+        }
+
+        [Fact]
         public void ExpectFullKeyManagerStoreRetrieveToSucceed()
         {
             var config = new KmsXmlEncryptorConfig(KmsIntegrationTests.ApplicationName, KmsIntegrationTests.KmsTestingKey);
 
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddInstance(kmsClient);
-            serviceCollection.AddInstance<IAuthenticatedEncryptorConfiguration>(new AuthenticatedEncryptorConfiguration(new AuthenticatedEncryptionOptions()));
             serviceCollection.AddDataProtection();
             serviceCollection.ConfigureDataProtection(configure =>
             {

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/S3IntegrationTests.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/S3IntegrationTests.cs
@@ -85,9 +85,9 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
         }
 
         [Fact]
-        public async Task ExpectBackwardsCompatibilityCompressedStoreRetrieveToSucceed()
+        public async Task ExpectCompatibilityToCompressedStoreRetrieveToSucceed()
         {
-            config.KeyPrefix = "BackwardsCompatibilityCompressTesting/";
+            config.KeyPrefix = "ForwardsCompatibilityCompressTesting/";
             config.ClientSideCompression = false;
 
             var myXml = new XElement(ElementName, ElementContent);
@@ -96,6 +96,25 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             await xmlRepo.StoreElementAsync(myXml, myTestName, CancellationToken.None);
 
             config.ClientSideCompression = true;
+
+            var list = await xmlRepo.GetAllElementsAsync(CancellationToken.None);
+
+            Assert.Equal(1, list.Count);
+            Assert.True(XNode.DeepEquals(myXml, list.First()));
+        }
+
+        [Fact]
+        public async Task ExpectCompatibilityFromCompressedStoreRetrieveToSucceed()
+        {
+            config.KeyPrefix = "BackwardsCompatibilityCompressTesting/";
+            config.ClientSideCompression = true;
+
+            var myXml = new XElement(ElementName, ElementContent);
+            var myTestName = "friendly_compressed";
+
+            await xmlRepo.StoreElementAsync(myXml, myTestName, CancellationToken.None);
+
+            config.ClientSideCompression = false;
 
             var list = await xmlRepo.GetAllElementsAsync(CancellationToken.None);
 

--- a/src/AspNetCore.DataProtection.Aws.Kms/DataProtectionBuilderExtensions.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/DataProtectionBuilderExtensions.cs
@@ -11,9 +11,6 @@ namespace AspNetCore.DataProtection.Aws.Kms
     /// <summary>
     /// Extensions for configuring data protection using an <see cref="IDataProtectionBuilder"/>.
     /// </summary>
-    /// <remarks>
-    /// Taken almost verbatim from https://github.com/aspnet/DataProtection/blob/release/src/Microsoft.AspNetCore.DataProtection/DataProtectionBuilderExtensions.cs
-    /// </remarks>
     public static class DataProtectionBuilderExtensions
     {
         /// <summary>
@@ -44,6 +41,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
             // Need to ensure KmsXmlDecryptor can actually be constructed
             Use(builder.Services, ServiceDescriptor.Singleton(services => kmsClient));
             Use(builder.Services, ServiceDescriptor.Singleton(services => config));
+            Use(builder.Services, ServiceDescriptor.Singleton<IKmsXmlEncryptorConfig>(services => config));
             Use(builder.Services, ServiceDescriptor.Singleton(services => new KmsXmlDecryptor(services)));
             Use(builder.Services, ServiceDescriptor.Singleton<IXmlDecryptor>(services => services.GetRequiredService<KmsXmlDecryptor>()));
             return builder;
@@ -70,6 +68,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
             Use(builder.Services, ServiceDescriptor.Singleton<IXmlEncryptor>(services => new KmsXmlEncryptor(services.GetRequiredService<IAmazonKeyManagementService>(), config, services)));
             // Need to ensure KmsXmlDecryptor can actually be constructed
             Use(builder.Services, ServiceDescriptor.Singleton(services => config));
+            Use(builder.Services, ServiceDescriptor.Singleton<IKmsXmlEncryptorConfig>(services => config));
             Use(builder.Services, ServiceDescriptor.Singleton(services => new KmsXmlDecryptor(services)));
             Use(builder.Services, ServiceDescriptor.Singleton<IXmlDecryptor>(services => services.GetRequiredService<KmsXmlDecryptor>()));
             return builder;

--- a/src/AspNetCore.DataProtection.Aws.Kms/KmsConstants.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/KmsConstants.cs
@@ -2,20 +2,20 @@
 // Licensed under the MIT License. See License.md in the project root for license information.
 namespace AspNetCore.DataProtection.Aws.Kms
 {
+    /// <summary>
+    /// Additional context supplied to all KMS operations used by AspNetCore.DataProtection.Aws.Kms
+    /// </summary>
+    /// <remarks>
+    /// This is not sensitive data - it simply prevents arbitrary use of a KMS master key to decrypt
+    /// the XML without this context supplied.
+    /// 
+    /// It is expected that clients will supply additional context such as their application name.
+    /// 
+    /// These strings should remain unchanged, rather than reflect any code or namespace - they're
+    /// only written as a namespace for easy disambiguation.
+    /// </remarks>
     public static class KmsConstants
     {
-        /// <summary>
-        /// Additional context supplied to all KMS operations used by AspNetCore.DataProtection.Aws.Kms
-        /// </summary>
-        /// <remarks>
-        /// This is not sensitive data - it simply prevents arbitrary use of a KMS master key to decrypt
-        /// the XML without this context supplied.
-        /// 
-        /// It is expected that clients will supply additional context such as their application name.
-        /// 
-        /// These strings should remain unchanged, rather than reflect any code or namespace - they're
-        /// only written as a namespace for easy disambiguation.
-        /// </remarks>
         public const string DefaultEncryptionContextKey = "AspNetCore.DataProtection.Aws.Kms.Xml";
         public const string DefaultEncryptionContextValue = "b7b7f5af-d3c3-436d-8792-87dfd65e1cd4";
         public const string ApplicationEncryptionContextKey = "AspNetCore.DataProtection.Aws.Kms.Xml.ApplicationName";

--- a/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlDecryptor.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlDecryptor.cs
@@ -23,7 +23,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// <remarks>
         /// DataProtection has a fairly awful way of making the IXmlDecryptor that by default never just does
         /// GetRequiredService<IXmlDecryptor>, instead calling the IServiceProvider constructor directly.
-        /// This means we have to do the resolution of needed objects via DI.
+        /// This means we have to do the resolution of needed objects via IServiceProvider.
         /// </remarks>
         /// <param name="services">A mandatory <see cref="IServiceProvider"/> to provide services.</param>
         public KmsXmlDecryptor(IServiceProvider services)
@@ -34,7 +34,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
             }
 
             KmsClient = services.GetRequiredService<IAmazonKeyManagementService>();
-            Config = services.GetRequiredService<KmsXmlEncryptorConfig>();
+            Config = services.GetRequiredService<IKmsXmlEncryptorConfig>();
             Services = services;
             _logger = services.GetService<ILoggerFactory>()?.CreateLogger<KmsXmlDecryptor>();
         }
@@ -42,7 +42,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// <summary>
         /// The configuration of how KMS will decrypt the XML data.
         /// </summary>
-        public KmsXmlEncryptorConfig Config { get; }
+        public IKmsXmlEncryptorConfig Config { get; }
 
         /// <summary>
         /// The <see cref="IServiceProvider"/> provided to the constructor.

--- a/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlEncryptor.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlEncryptor.cs
@@ -22,7 +22,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// </summary>
         /// <param name="kmsClient">The KMS client.</param>
         /// <param name="config">The configuration object specifying which key data in KMS to use.</param>
-        public KmsXmlEncryptor(IAmazonKeyManagementService kmsClient, KmsXmlEncryptorConfig config)
+        public KmsXmlEncryptor(IAmazonKeyManagementService kmsClient, IKmsXmlEncryptorConfig config)
             : this(kmsClient, config, services: null)
         {
         }
@@ -33,7 +33,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// <param name="kmsClient">The KMS client.</param>
         /// <param name="config">The configuration object specifying which key data in KMS to use.</param>
         /// <param name="services">An optional <see cref="IServiceProvider"/> to provide ancillary services.</param>
-        public KmsXmlEncryptor(IAmazonKeyManagementService kmsClient, KmsXmlEncryptorConfig config, IServiceProvider services)
+        public KmsXmlEncryptor(IAmazonKeyManagementService kmsClient, IKmsXmlEncryptorConfig config, IServiceProvider services)
         {
             if (kmsClient == null)
             {
@@ -54,7 +54,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// <summary>
         /// The configuration of how Kms will encrypt the XML data.
         /// </summary>
-        public KmsXmlEncryptorConfig Config { get; }
+        public IKmsXmlEncryptorConfig Config { get; }
 
         /// <summary>
         /// The <see cref="IServiceProvider"/> provided to the constructor.

--- a/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlEncryptorConfig.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlEncryptorConfig.cs
@@ -4,7 +4,14 @@ using System.Collections.Generic;
 
 namespace AspNetCore.DataProtection.Aws.Kms
 {
-    public class KmsXmlEncryptorConfig
+    public interface IKmsXmlEncryptorConfig
+    {
+        Dictionary<string, string> EncryptionContext { get; }
+        List<string> GrantTokens { get; }
+        string KeyId { get; }
+    }
+
+    public class KmsXmlEncryptorConfig : IKmsXmlEncryptorConfig
     {
         // TODO Can we obtain DataProtectionOptions.ApplicationDiscriminator for this?
         public KmsXmlEncryptorConfig(string applicationName, string keyId)

--- a/src/AspNetCore.DataProtection.Aws.Kms/project.json
+++ b/src/AspNetCore.DataProtection.Aws.Kms/project.json
@@ -9,7 +9,7 @@
   },
   "owners": [ "hotchkj" ],
   "authors": [ "hotchkj" ],
-  "version": "1.0.0-alpha03",
+  "version": "1.0.0-alpha04",
 
   "compilationOptions": {
     "emitEntryPoint": false,

--- a/src/AspNetCore.DataProtection.Aws.S3/DataProtectionBuilderExtensions.cs
+++ b/src/AspNetCore.DataProtection.Aws.S3/DataProtectionBuilderExtensions.cs
@@ -11,9 +11,6 @@ namespace AspNetCore.DataProtection.Aws.S3
     /// <summary>
     /// Extensions for configuring data protection using an <see cref="IDataProtectionBuilder"/>.
     /// </summary>
-    /// <remarks>
-    /// Taken almost verbatim from https://github.com/aspnet/DataProtection/blob/release/src/Microsoft.AspNetCore.DataProtection/DataProtectionBuilderExtensions.cs
-    /// </remarks>
     public static class DataProtectionBuilderExtensions
     {
         /// <summary>

--- a/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepository.cs
+++ b/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepository.cs
@@ -149,9 +149,10 @@ namespace AspNetCore.DataProtection.Aws.S3
                     // Not that surprising considering that S3 treats the data as just N bytes; that it was compressed
                     // client-side doesn't really matter.
                     //
-                    // Backwards compatibility - if we set compress=true but load something without
-                    // gzip encoding then skip and load as uncompressed
-                    if (Config.ClientSideCompression && response.Headers.ContentEncoding == "gzip")
+                    // Compatibility: If we set compress=true but load something without gzip encoding then skip and
+                    // load as uncompressed. If we set compress=false but load something with gzip encoding, load as
+                    // compressed otherwise loading won't work.
+                    if (response.Headers.ContentEncoding == "gzip")
                     {
                         using (var responseStream = new GZipStream(response.ResponseStream, CompressionMode.Decompress))
                         {
@@ -219,6 +220,7 @@ namespace AspNetCore.DataProtection.Aws.S3
                 {
                     // Enable S3 to serve the content so that it automatically unzips in browser
                     // Note that this doesn't apply to the streams AWS SDK returns!
+                    // Also provides a very convenient discriminator for whether the key is compressed
                     pr.Headers.ContentEncoding = "gzip";
                     // Weird behaviour around GZipStream. Need to close, but then access the disposed MemoryStream!
                     using (var inputStream = new MemoryStream())

--- a/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepository.cs
+++ b/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepository.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using System.Collections.ObjectModel;
+using System.IO.Compression;
 
 namespace AspNetCore.DataProtection.Aws.S3
 {
@@ -29,7 +30,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         /// </summary>
         /// <param name="s3client">The S3 client.</param>
         /// <param name="config">The configuration object specifying how to write to S3.</param>
-        public S3XmlRepository(IAmazonS3 s3client, S3XmlRepositoryConfig config)
+        public S3XmlRepository(IAmazonS3 s3client, IS3XmlRepositoryConfig config)
             : this(s3client, config, services: null)
         {
         }
@@ -40,7 +41,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         /// <param name="s3client">The S3 client.</param>
 		/// <param name="config">The configuration object specifying how to write to S3.</param>
         /// <param name="services">An optional <see cref="IServiceProvider"/> to provide ancillary services.</param>
-        public S3XmlRepository(IAmazonS3 s3client, S3XmlRepositoryConfig config, IServiceProvider services)
+        public S3XmlRepository(IAmazonS3 s3client, IS3XmlRepositoryConfig config, IServiceProvider services)
         {
             if (s3client == null)
             {
@@ -61,7 +62,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         /// <summary>
         /// The bucket into which key material will be written.
         /// </summary>
-        public S3XmlRepositoryConfig Config { get; }
+        public IS3XmlRepositoryConfig Config { get; }
 
         /// <summary>
         /// The <see cref="IServiceProvider"/> provided to the constructor.
@@ -123,6 +124,7 @@ namespace AspNetCore.DataProtection.Aws.S3
             try
             {
                 _logger?.LogDebug("Retrieving DataProtection key at S3 location {0} in bucket {1}", item.Key, Config.Bucket);
+
                 var gr = new GetObjectRequest
                 {
                     BucketName = Config.Bucket,
@@ -135,6 +137,7 @@ namespace AspNetCore.DataProtection.Aws.S3
                     gr.ServerSideEncryptionCustomerProvidedKey = Config.ServerSideEncryptionCustomerProvidedKey;
                     gr.ServerSideEncryptionCustomerProvidedKeyMD5 = Config.ServerSideEncryptionCustomerProvidedKeyMD5;
                 }
+
                 using (var response = await S3Client.GetObjectAsync(gr, ct).ConfigureAwait(false))
                 {
                     // Skip empty folder keys
@@ -142,7 +145,23 @@ namespace AspNetCore.DataProtection.Aws.S3
                     {
                         return null;
                     }
-                    return XElement.Load(response.ResponseStream);
+                    // Stream returned from AWS SDK does not automatically uncompress even with ContentEncoding set
+                    // Not that surprising considering that S3 treats the data as just N bytes; that it was compressed
+                    // client-side doesn't really matter.
+                    //
+                    // Backwards compatibility - if we set compress=true but load something without
+                    // gzip encoding then skip and load as uncompressed
+                    if (Config.ClientSideCompression && response.Headers.ContentEncoding == "gzip")
+                    {
+                        using (var responseStream = new GZipStream(response.ResponseStream, CompressionMode.Decompress))
+                        {
+                            return XElement.Load(responseStream);
+                        }
+                    }
+                    else
+                    {
+                        return XElement.Load(response.ResponseStream);
+                    }
                 }
             }
             finally
@@ -171,38 +190,59 @@ namespace AspNetCore.DataProtection.Aws.S3
                 _logger?.LogDebug("Storing DataProtection key at S3 location {0} in bucket {1}", key, Config.Bucket);
             }
 
-            using (var stream = new MemoryStream())
+            var pr = new PutObjectRequest
             {
-                element.Save(stream);
-                stream.Seek(0, SeekOrigin.Begin);
+                BucketName = Config.Bucket,
+                Key = key,
+                ServerSideEncryptionMethod = Config.ServerSideEncryptionMethod,
+                ServerSideEncryptionCustomerMethod = ServerSideEncryptionCustomerMethod.None,
+                AutoResetStreamPosition = false,
+                AutoCloseStream = true,
+                ContentType = "text/xml",
+                StorageClass = Config.StorageClass
+            };
+            if (Config.ServerSideEncryptionMethod == ServerSideEncryptionMethod.AWSKMS)
+            {
+                pr.ServerSideEncryptionKeyManagementServiceKeyId = Config.ServerSideEncryptionKeyManagementServiceKeyId;
+            }
+            else if (Config.ServerSideEncryptionCustomerMethod != ServerSideEncryptionCustomerMethod.None)
+            {
+                pr.ServerSideEncryptionMethod = ServerSideEncryptionMethod.None;
+                pr.ServerSideEncryptionCustomerMethod = Config.ServerSideEncryptionCustomerMethod;
+                pr.ServerSideEncryptionCustomerProvidedKey = Config.ServerSideEncryptionCustomerProvidedKey;
+                pr.ServerSideEncryptionCustomerProvidedKeyMD5 = Config.ServerSideEncryptionCustomerProvidedKeyMD5;
+            }
 
+            using (var outputStream = new MemoryStream())
+            {
+                if (Config.ClientSideCompression)
+                {
+                    // Enable S3 to serve the content so that it automatically unzips in browser
+                    // Note that this doesn't apply to the streams AWS SDK returns!
+                    pr.Headers.ContentEncoding = "gzip";
+                    // Weird behaviour around GZipStream. Need to close, but then access the disposed MemoryStream!
+                    using (var inputStream = new MemoryStream())
+                    {
+                        using (var gZippedstream = new GZipStream(inputStream, CompressionMode.Compress))
+                        {
+                            element.Save(gZippedstream);
+                        }
+                        var inputArray = inputStream.ToArray();
+                        await outputStream.WriteAsync(inputArray, 0, inputArray.Length, ct);
+                    }
+                }
+                else
+                {
+                    element.Save(outputStream);
+                }
+
+                outputStream.Seek(0, SeekOrigin.Begin);
                 var hasher = MD5.Create();
-                var md5 = Convert.ToBase64String(hasher.ComputeHash(stream));
+                pr.MD5Digest = Convert.ToBase64String(hasher.ComputeHash(outputStream));
 
-                var pr = new PutObjectRequest
-                {
-                    BucketName = Config.Bucket,
-                    Key = key,
-                    InputStream = stream,
-                    ServerSideEncryptionMethod = Config.ServerSideEncryptionMethod,
-                    ServerSideEncryptionCustomerMethod = ServerSideEncryptionCustomerMethod.None,
-                    AutoResetStreamPosition = true,
-                    AutoCloseStream = true,
-                    MD5Digest = md5,
-                    ContentType = "text/xml",
-                    StorageClass = Config.StorageClass
-                };
-                if(Config.ServerSideEncryptionMethod == ServerSideEncryptionMethod.AWSKMS)
-                {
-                    pr.ServerSideEncryptionKeyManagementServiceKeyId = Config.ServerSideEncryptionKeyManagementServiceKeyId;
-                }
-                else if (Config.ServerSideEncryptionCustomerMethod != ServerSideEncryptionCustomerMethod.None)
-                {
-                    pr.ServerSideEncryptionMethod = ServerSideEncryptionMethod.None;
-                    pr.ServerSideEncryptionCustomerMethod = Config.ServerSideEncryptionCustomerMethod;
-                    pr.ServerSideEncryptionCustomerProvidedKey = Config.ServerSideEncryptionCustomerProvidedKey;
-                    pr.ServerSideEncryptionCustomerProvidedKeyMD5 = Config.ServerSideEncryptionCustomerProvidedKeyMD5;
-                }
+                outputStream.Seek(0, SeekOrigin.Begin);
+                pr.InputStream = outputStream;
+
                 await S3Client.PutObjectAsync(pr, ct).ConfigureAwait(false);
             }
         }

--- a/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepositoryConfig.cs
+++ b/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepositoryConfig.cs
@@ -5,7 +5,21 @@ using System;
 
 namespace AspNetCore.DataProtection.Aws.S3
 {
-    public class S3XmlRepositoryConfig
+    public interface IS3XmlRepositoryConfig
+    {
+        string Bucket { get; }
+        int MaxS3QueryConcurrency { get; }
+        S3StorageClass StorageClass { get; }
+        string KeyPrefix { get; }
+        ServerSideEncryptionMethod ServerSideEncryptionMethod { get; }
+        ServerSideEncryptionCustomerMethod ServerSideEncryptionCustomerMethod { get; }
+        string ServerSideEncryptionCustomerProvidedKey { get; }
+        string ServerSideEncryptionCustomerProvidedKeyMD5 { get; }
+        string ServerSideEncryptionKeyManagementServiceKeyId { get; }
+        bool ClientSideCompression { get; }
+    }
+
+    public class S3XmlRepositoryConfig : IS3XmlRepositoryConfig
     {
         public S3XmlRepositoryConfig(string bucketName)
         {
@@ -23,6 +37,7 @@ namespace AspNetCore.DataProtection.Aws.S3
             ServerSideEncryptionCustomerProvidedKey = null;
             ServerSideEncryptionCustomerProvidedKeyMD5 = null;
             ServerSideEncryptionKeyManagementServiceKeyId = null;
+            ClientSideCompression = true;
         }
 
         public string Bucket { get; set; }
@@ -38,7 +53,7 @@ namespace AspNetCore.DataProtection.Aws.S3
             {
                 if (!S3XmlRepository.IsSafeS3Key(value))
                 {
-                    throw new ArgumentException("Specified key prefix is not considered a safe S3 name", "value");
+                    throw new ArgumentException($"Specified key prefix {value} is not considered a safe S3 name", "value");
                 }
                 _keyPrefix = value;
             }
@@ -48,6 +63,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         public string ServerSideEncryptionCustomerProvidedKey { get; set; }
         public string ServerSideEncryptionCustomerProvidedKeyMD5 { get; set; }
         public string ServerSideEncryptionKeyManagementServiceKeyId { get; set; }
+        public bool ClientSideCompression { get; set; }
 
         private string _keyPrefix;
     }

--- a/src/AspNetCore.DataProtection.Aws.S3/project.json
+++ b/src/AspNetCore.DataProtection.Aws.S3/project.json
@@ -9,7 +9,7 @@
   },
   "owners": [ "hotchkj" ],
   "authors": [ "hotchkj" ],
-  "version": "1.0.0-alpha03",
+  "version": "1.0.0-alpha04",
 
   "compilationOptions": {
     "emitEntryPoint": false,


### PR DESCRIPTION
…ding is set so that download by other means automatically considers the result gzipped XML. Backwards compatibility is ensured by looking for this header prior to choosing to unzip.

Also tidies up unit testing & interfaces to allow for more mocking & removing incorrect assumptions about how xunit runs tests in parallel.
Adds integration test for both forms of configuration.

Closes #5