### PR TITLE
.NET Core RTM build

### DIFF
--- a/AspNetCore.DataProtection.Aws.sln
+++ b/AspNetCore.DataProtection.Aws.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{851F9F19-EAF9-4C8C-81CD-0C89D4083928}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -16,28 +16,25 @@ In Startup.cs, specified as part of DataProtection configuration:
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddDataProtection();
-    services.ConfigureDataProtection(configure =>
-    {
-        configure.PersistKeysToAwsS3(new AmazonS3Client(), new S3XmlRepositoryConfig("my-bucket-name")
-        // Configuration has defaults; all below are optional
-        {
-            // How many concurrent connections will be made to S3 to retrieve key data
-            MaxS3QueryConcurrency = 10,
-            // Custom prefix in the S3 bucket enabling use of folders
-            KeyPrefix = "MyKeys/",
-            // Customise storage class for key storage
-            StorageClass = S3StorageClass.Standard,
-            // Customise encryption options (these can be mutually exclusive - don't just copy & paste!)
-            ServerSideEncryptionMethod = ServerSideEncryptionMethod.AES256,
-            ServerSideEncryptionCustomerMethod = ServerSideEncryptionCustomerMethod.AES256,
-            ServerSideEncryptionCustomerProvidedKey = "MyBase64Key",
-            ServerSideEncryptionCustomerProvidedKeyMD5 = "MD5OfMyBase64Key",
-            ServerSideEncryptionKeyManagementServiceKeyId = "AwsKeyManagementServiceId",
-            // Compress stored XML before write to S3
-            ClientSideCompression = true
-        });
-    });
+    services.AddDataProtection()
+            .PersistKeysToAwsS3(new AmazonS3Client(), new S3XmlRepositoryConfig("my-bucket-name")
+            // Configuration has defaults; all below are optional
+            {
+                // How many concurrent connections will be made to S3 to retrieve key data
+                MaxS3QueryConcurrency = 10,
+                // Custom prefix in the S3 bucket enabling use of folders
+                KeyPrefix = "MyKeys/",
+                // Customise storage class for key storage
+                StorageClass = S3StorageClass.Standard,
+                // Customise encryption options (these can be mutually exclusive - don't just copy & paste!)
+                ServerSideEncryptionMethod = ServerSideEncryptionMethod.AES256,
+                ServerSideEncryptionCustomerMethod = ServerSideEncryptionCustomerMethod.AES256,
+                ServerSideEncryptionCustomerProvidedKey = "MyBase64Key",
+                ServerSideEncryptionCustomerProvidedKeyMD5 = "MD5OfMyBase64Key",
+                ServerSideEncryptionKeyManagementServiceKeyId = "AwsKeyManagementServiceId",
+                // Compress stored XML before write to S3
+                ClientSideCompression = true
+            });
 }
 ```
 If the `IAmazonS3` interface is discoverable via Dependency Injection in `IServiceCollection`, the constructor argument of `AmazonS3Client` can be omitted.
@@ -54,15 +51,13 @@ In Startup.cs, specified as part of DataProtection configuration:
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddDataProtection();
-    services.ConfigureDataProtection(configure =>
-    {
-        var kmsConfig = new KmsXmlEncryptorConfig("my-application-name", "alias/MyKmsAlias");
-        // Configuration has default contexts added; below are optional if using grants or additional contexts
-        kmsConfig.EncryptionContext.Add("my-custom-context", "my-custom-value");
-        kmsConfig.GrantTokens.Add("my-grant-token");
-        configure.ProtectKeysWithAwsKms(new AmazonKeyManagementServiceClient(), kmsConfig);
-    });
+    var kmsConfig = new KmsXmlEncryptorConfig("my-application-name", "alias/MyKmsAlias");
+    // Configuration has default contexts added; below are optional if using grants or additional contexts
+    kmsConfig.EncryptionContext.Add("my-custom-context", "my-custom-value");
+    kmsConfig.GrantTokens.Add("my-grant-token");
+
+    services.AddDataProtection()
+            .ProtectKeysWithAwsKms(new AmazonKeyManagementServiceClient(), kmsConfig);
 }
 ```
 If the `IAmazonKeyManagementService` interface is discoverable via Dependency Injection in `IServiceCollection`, the constructor argument of `AmazonKeyManagementServiceClient` can be omitted.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,3 @@
 ﻿{
-  "projects": [ "src", "test" ],
-  "sdk": {
-    "version": "1.0.0-rc1-final"
-  }
+  "projects": [ "src", "test", "integrate" ]
 }

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/AspNetCore.DataProtection.Aws.IntegrationTests.xproj
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/AspNetCore.DataProtection.Aws.IntegrationTests.xproj
@@ -4,12 +4,12 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>d19ebbf5-fa0e-4ec5-a11f-9b5ac1165b39</ProjectGuid>
     <RootNamespace>AspNetCore.DataProtection.Aws.IntegrationTests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
@@ -17,5 +17,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/CombinedManagerIntegrationTests.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/CombinedManagerIntegrationTests.cs
@@ -5,9 +5,9 @@ using Amazon.KeyManagementService;
 using Amazon.S3;
 using AspNetCore.DataProtection.Aws.Kms;
 using AspNetCore.DataProtection.Aws.S3;
-using Microsoft.AspNet.DataProtection.AuthenticatedEncryption.ConfigurationModel;
-using Microsoft.AspNet.DataProtection.KeyManagement;
-using Microsoft.AspNet.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
@@ -45,12 +45,9 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             var kmsConfig = new KmsXmlEncryptorConfig(KmsIntegrationTests.ApplicationName, KmsIntegrationTests.KmsTestingKey);
 
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddDataProtection();
-            serviceCollection.ConfigureDataProtection(configure =>
-            {
-                configure.PersistKeysToAwsS3(s3client, s3Config);
-                configure.ProtectKeysWithAwsKms(kmsClient, kmsConfig);
-            });
+            serviceCollection.AddDataProtection()
+                             .PersistKeysToAwsS3(s3client, s3Config)
+                             .ProtectKeysWithAwsKms(kmsClient, kmsConfig);
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var keyManager = new XmlKeyManager(serviceProvider.GetRequiredService<IXmlRepository>(),
@@ -77,14 +74,11 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             var kmsConfig = new KmsXmlEncryptorConfig(KmsIntegrationTests.ApplicationName, KmsIntegrationTests.KmsTestingKey);
 
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddInstance(s3client);
-            serviceCollection.AddInstance(kmsClient);
-            serviceCollection.AddDataProtection();
-            serviceCollection.ConfigureDataProtection(configure =>
-            {
-                configure.PersistKeysToAwsS3(s3Config);
-                configure.ProtectKeysWithAwsKms(kmsConfig);
-            });
+            serviceCollection.AddSingleton(s3client);
+            serviceCollection.AddSingleton(kmsClient);
+            serviceCollection.AddDataProtection()
+                             .PersistKeysToAwsS3(s3Config)
+                             .ProtectKeysWithAwsKms(kmsConfig);
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var keyManager = new XmlKeyManager(serviceProvider.GetRequiredService<IXmlRepository>(),

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/EphemeralXmlRepository.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/EphemeralXmlRepository.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 //
 // Copied verbatim as a useful testing internal implementation detail
-using Microsoft.AspNet.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/KmsManagerIntegrationTests.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/KmsManagerIntegrationTests.cs
@@ -3,9 +3,9 @@
 using Amazon;
 using Amazon.KeyManagementService;
 using AspNetCore.DataProtection.Aws.Kms;
-using Microsoft.AspNet.DataProtection.AuthenticatedEncryption.ConfigurationModel;
-using Microsoft.AspNet.DataProtection.KeyManagement;
-using Microsoft.AspNet.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
@@ -34,12 +34,9 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             var config = new KmsXmlEncryptorConfig(KmsIntegrationTests.ApplicationName, KmsIntegrationTests.KmsTestingKey);
 
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddDataProtection();
-            serviceCollection.ConfigureDataProtection(configure =>
-            {
-                configure.ProtectKeysWithAwsKms(kmsClient, config);
-            });
-            serviceCollection.AddInstance<IXmlRepository>(new EphemeralXmlRepository());
+            serviceCollection.AddDataProtection()
+                             .ProtectKeysWithAwsKms(kmsClient, config);
+            serviceCollection.AddSingleton<IXmlRepository, EphemeralXmlRepository>();
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var keyManager = new XmlKeyManager(serviceProvider.GetRequiredService<IXmlRepository>(),
@@ -63,13 +60,10 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             var config = new KmsXmlEncryptorConfig(KmsIntegrationTests.ApplicationName, KmsIntegrationTests.KmsTestingKey);
 
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddInstance(kmsClient);
-            serviceCollection.AddDataProtection();
-            serviceCollection.ConfigureDataProtection(configure =>
-            {
-                configure.ProtectKeysWithAwsKms(config);
-            });
-            serviceCollection.AddInstance<IXmlRepository>(new EphemeralXmlRepository());
+            serviceCollection.AddSingleton(kmsClient);
+            serviceCollection.AddDataProtection()
+                             .ProtectKeysWithAwsKms(config);
+            serviceCollection.AddSingleton<IXmlRepository, EphemeralXmlRepository>();
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var keyManager = new XmlKeyManager(serviceProvider.GetRequiredService<IXmlRepository>(),

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/S3ManagerIntegrationTests.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/S3ManagerIntegrationTests.cs
@@ -3,9 +3,9 @@
 using Amazon;
 using Amazon.S3;
 using AspNetCore.DataProtection.Aws.S3;
-using Microsoft.AspNet.DataProtection.AuthenticatedEncryption.ConfigurationModel;
-using Microsoft.AspNet.DataProtection.KeyManagement;
-using Microsoft.AspNet.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
@@ -39,11 +39,8 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             await s3cleanup.ClearKeys(S3IntegrationTests.BucketName, config.KeyPrefix);
 
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddDataProtection();
-            serviceCollection.ConfigureDataProtection(configure =>
-            {
-                configure.PersistKeysToAwsS3(s3client, config);
-            });
+            serviceCollection.AddDataProtection()
+                             .PersistKeysToAwsS3(s3client, config);
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var keyManager = new XmlKeyManager(serviceProvider.GetRequiredService<IXmlRepository>(),
@@ -69,12 +66,9 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             await s3cleanup.ClearKeys(S3IntegrationTests.BucketName, config.KeyPrefix);
 
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddInstance(s3client);
-            serviceCollection.AddDataProtection();
-            serviceCollection.ConfigureDataProtection(configure =>
-            {
-                configure.PersistKeysToAwsS3(config);
-            });
+            serviceCollection.AddSingleton(s3client);
+            serviceCollection.AddDataProtection()
+                             .PersistKeysToAwsS3(config);
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var keyManager = new XmlKeyManager(serviceProvider.GetRequiredService<IXmlRepository>(),

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/project.json
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/project.json
@@ -21,14 +21,6 @@
         "Microsoft.NETCore.Platforms": "1.0.1",
         "System.Threading.Tasks": "4.0.0.0"
       }
-    },
-    "netcoreapp1.0": {
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "type": "platform",
-          "version": "1.0.0"
-        }
-      }
     }
   }
 }

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/project.json
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/project.json
@@ -1,29 +1,33 @@
 {
-  "summary": "ASP.NET DataProtection Repository Integration Tests",
-  "licenseUrl": "https://opensource.org/licenses/MIT",
-  "owners": [ "hotchkj" ],
   "authors": [ "hotchkj" ],
   "version": "1.0.0-*",
+  "testRunner": "xunit",
 
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true
   },
 
-  "commands": {
-    "integrate": "xunit.runner.dnx -parallel all"
-  },
-
   "dependencies": {
-    "AspNetCore.DataProtection.Aws.S3": "",
-    "AspNetCore.DataProtection.Aws.Kms": "",
-    "xunit": "2.1.0",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc1-final"
+    "AspNetCore.DataProtection.Aws.Kms": "1.0.0-*",
+    "AspNetCore.DataProtection.Aws.S3": "1.0.0-*",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
+    "xunit": "2.2.0-beta2-build3300"
   },
 
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
-        "xunit.runner.dnx": "2.1.0-rc1-build204"
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "System.Threading.Tasks": "4.0.0.0"
+      }
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
       }
     }
   }

--- a/src/AspNetCore.DataProtection.Aws.Kms/AspNetCore.DataProtection.Aws.Kms.xproj
+++ b/src/AspNetCore.DataProtection.Aws.Kms/AspNetCore.DataProtection.Aws.Kms.xproj
@@ -4,15 +4,16 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>405c524a-e843-43eb-8164-60976e3a4df1</ProjectGuid>
     <RootNamespace>AspNetCore.DataProtection.Aws.Kms</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/AspNetCore.DataProtection.Aws.Kms/DataProtectionBuilderExtensions.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/DataProtectionBuilderExtensions.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See License.md in the project root for license information.
 using Amazon.KeyManagementService;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.AspNet.DataProtection;
-using Microsoft.AspNet.DataProtection.XmlEncryption;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
 using System;
 
 namespace AspNetCore.DataProtection.Aws.Kms
@@ -20,7 +20,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// <param name="kmsClient">KMS client configured with appropriate credentials.</param>
         /// <param name="config">The configuration object specifying how use KMS keys.</param>
         /// <returns>A reference to the <see cref="DataProtectionConfiguration" /> after this operation has completed.</returns>
-        public static DataProtectionConfiguration ProtectKeysWithAwsKms(this DataProtectionConfiguration builder, IAmazonKeyManagementService kmsClient, KmsXmlEncryptorConfig config)
+        public static IDataProtectionBuilder ProtectKeysWithAwsKms(this IDataProtectionBuilder builder, IAmazonKeyManagementService kmsClient, KmsXmlEncryptorConfig config)
         {
             if (builder == null)
             {
@@ -53,7 +53,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// <param name="builder">The <see cref="DataProtectionConfiguration"/>.</param>
         /// <param name="config">The configuration object specifying how use KMS keys.</param>
         /// <returns>A reference to the <see cref="DataProtectionConfiguration" /> after this operation has completed.</returns>
-        public static DataProtectionConfiguration ProtectKeysWithAwsKms(this DataProtectionConfiguration builder, KmsXmlEncryptorConfig config)
+        public static IDataProtectionBuilder ProtectKeysWithAwsKms(this IDataProtectionBuilder builder, KmsXmlEncryptorConfig config)
         {
             if (builder == null)
             {

--- a/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlDecryptor.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlDecryptor.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.md in the project root for license information.
 using Amazon.KeyManagementService;
 using Amazon.KeyManagementService.Model;
-using Microsoft.AspNet.DataProtection.XmlEncryption;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlEncryptor.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlEncryptor.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.md in the project root for license information.
 using Amazon.KeyManagementService;
 using Amazon.KeyManagementService.Model;
-using Microsoft.AspNet.DataProtection.XmlEncryption;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/AspNetCore.DataProtection.Aws.Kms/project.json
+++ b/src/AspNetCore.DataProtection.Aws.Kms/project.json
@@ -1,7 +1,8 @@
 {
   "description": "DataProtection encrypter & decrypter for use with AWS KMS",
-  "authors": [ "hotchkj" ],
   "version": "1.0.0-beta01",
+  "authors": [ "hotchkj" ],
+  "owners": [ "hotchkj" ],
 
   "packOptions": {
     "owners": [ "hotchkj" ],

--- a/src/AspNetCore.DataProtection.Aws.Kms/project.json
+++ b/src/AspNetCore.DataProtection.Aws.Kms/project.json
@@ -1,25 +1,29 @@
 {
-  "summary": "ASP.NET AWS KMS DataProtection Cryptography",
-  "description": "DataProtection encrypter & decrypter for use with AWS KMS (DNX RC1)",
-  "projectUrl": "https://github.com/hotchkj/AspNetCore.DataProtection.Aws",
-  "licenseUrl": "https://opensource.org/licenses/MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/hotchkj/AspNetCore.DataProtection.Aws"
-  },
-  "owners": [ "hotchkj" ],
+  "description": "DataProtection encrypter & decrypter for use with AWS KMS",
   "authors": [ "hotchkj" ],
-  "version": "1.0.0-alpha05",
+  "version": "1.0.0-beta01",
 
-  "compilationOptions": {
+  "packOptions": {
+    "owners": [ "hotchkj" ],
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/hotchkj/AspNetCore.DataProtection.Aws"
+    },
+    "summary": "ASP.NET AWS KMS DataProtection Cryptography",
+    "tags": [ "ASP.NET", "AWS", "DataProtection", "netcore" ],
+    "releaseNotes": "Updated to .NET Core",
+    "projectUrl": "https://github.com/hotchkj/AspNetCore.DataProtection.Aws",
+    "licenseUrl": "https://opensource.org/licenses/MIT"
+  },
+
+  "buildOptions": {
     "emitEntryPoint": false,
-    "warningsAsErrors": true,
-    "keyFile": "../../shared.snk"
+    "warningsAsErrors": true
   },
 
   "dependencies": {
-    "AWSSDK.KeyManagementService": "3.1.2.2",
-    "Microsoft.AspNet.DataProtection": "1.0.0-rc1-final"
+    "AWSSDK.KeyManagementService": "3.2.5-beta",
+    "Microsoft.AspNetCore.DataProtection": "1.0.0"
   },
 
   "frameworks": {
@@ -27,7 +31,11 @@
       "dependencies": {
       }
     },
-    "dnx451": {
+    "netcore50": {
+      "dependencies": {
+      }
+    },
+    "netstandard1.5": {
       "dependencies": {
       }
     }

--- a/src/AspNetCore.DataProtection.Aws.S3/AspNetCore.DataProtection.Aws.S3.xproj
+++ b/src/AspNetCore.DataProtection.Aws.S3/AspNetCore.DataProtection.Aws.S3.xproj
@@ -4,15 +4,16 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>a36a5d31-f6f5-4594-8326-1b5ff5877e8a</ProjectGuid>
     <RootNamespace>AspNetCore.DataProtection.Aws.S3</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/AspNetCore.DataProtection.Aws.S3/DataProtectionBuilderExtensions.cs
+++ b/src/AspNetCore.DataProtection.Aws.S3/DataProtectionBuilderExtensions.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See License.md in the project root for license information.
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.AspNet.DataProtection;
-using Microsoft.AspNet.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 using Amazon.S3;
 
 namespace AspNetCore.DataProtection.Aws.S3
@@ -20,7 +20,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         /// <param name="s3Client">S3 client configured with appropriate credentials.</param>
         /// <param name="config">The configuration object specifying how to write to S3.</param>
         /// <returns>A reference to the <see cref="DataProtectionConfiguration" /> after this operation has completed.</returns>
-        public static DataProtectionConfiguration PersistKeysToAwsS3(this DataProtectionConfiguration builder, IAmazonS3 s3Client, S3XmlRepositoryConfig config)
+        public static IDataProtectionBuilder PersistKeysToAwsS3(this IDataProtectionBuilder builder, IAmazonS3 s3Client, S3XmlRepositoryConfig config)
         {
             if (builder == null)
             {
@@ -48,7 +48,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         /// <param name="builder">The <see cref="DataProtectionConfiguration"/>.</param>
         /// <param name="config">The configuration object specifying how to write to S3.</param>
         /// <returns>A reference to the <see cref="DataProtectionConfiguration" /> after this operation has completed.</returns>
-        public static DataProtectionConfiguration PersistKeysToAwsS3(this DataProtectionConfiguration builder, S3XmlRepositoryConfig config)
+        public static IDataProtectionBuilder PersistKeysToAwsS3(this IDataProtectionBuilder builder, S3XmlRepositoryConfig config)
         {
             if (builder == null)
             {

--- a/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepository.cs
+++ b/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepository.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.md in the project root for license information.
 using Amazon.S3;
 using Amazon.S3.Model;
-using Microsoft.AspNet.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/AspNetCore.DataProtection.Aws.S3/project.json
+++ b/src/AspNetCore.DataProtection.Aws.S3/project.json
@@ -1,7 +1,8 @@
 {
-  "description": "DataProtection repository for use with AWS S3 (DNX RC1)",
-  "authors": [ "hotchkj" ],
+  "description": "DataProtection repository for use with AWS S3",
   "version": "1.0.0-beta01",
+  "authors": [ "hotchkj" ],
+  "owners": [ "hotchkj" ],
 
   "packOptions": {
     "owners": [ "hotchkj" ],

--- a/src/AspNetCore.DataProtection.Aws.S3/project.json
+++ b/src/AspNetCore.DataProtection.Aws.S3/project.json
@@ -1,25 +1,29 @@
 {
-  "summary": "ASP.NET AWS S3 DataProtection Repository",
   "description": "DataProtection repository for use with AWS S3 (DNX RC1)",
-  "projectUrl": "https://github.com/hotchkj/AspNetCore.DataProtection.Aws",
-  "licenseUrl": "https://opensource.org/licenses/MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/hotchkj/AspNetCore.DataProtection.Aws"
-  },
-  "owners": [ "hotchkj" ],
   "authors": [ "hotchkj" ],
-  "version": "1.0.0-alpha05",
+  "version": "1.0.0-beta01",
 
-  "compilationOptions": {
+  "packOptions": {
+    "owners": [ "hotchkj" ],
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/hotchkj/AspNetCore.DataProtection.Aws"
+    },
+    "summary": "ASP.NET AWS S3 DataProtection Repository",
+    "tags": [ "ASP.NET", "AWS", "DataProtection", "netcore" ],
+    "releaseNotes": "Updated to .NET Core",
+    "projectUrl": "https://github.com/hotchkj/AspNetCore.DataProtection.Aws",
+    "licenseUrl": "https://opensource.org/licenses/MIT"
+  },
+
+  "buildOptions": {
     "emitEntryPoint": false,
-    "warningsAsErrors": true,
-    "keyFile": "../../shared.snk"
+    "warningsAsErrors": true
   },
 
   "dependencies": {
-    "AWSSDK.S3": "3.1.7",
-    "Microsoft.AspNet.DataProtection": "1.0.0-rc1-final"
+    "AWSSDK.S3": "3.2.5-beta",
+    "Microsoft.AspNetCore.DataProtection": "1.0.0"
   },
 
   "frameworks": {
@@ -27,8 +31,14 @@
       "dependencies": {
       }
     },
-    "dnx451": {
+    "netcore50": {
       "dependencies": {
+        "System.IO.Compression": "4.1.0"
+      }
+    },
+    "netstandard1.5": {
+      "dependencies": {
+        "System.IO.Compression": "4.1.0"
       }
     }
   }

--- a/test/AspNetCore.DataProtection.Aws.Tests/AspNetCore.DataProtection.Aws.Tests.xproj
+++ b/test/AspNetCore.DataProtection.Aws.Tests/AspNetCore.DataProtection.Aws.Tests.xproj
@@ -4,12 +4,12 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>37914c81-00e7-4fe5-887c-795e9de81463</ProjectGuid>
-    <RootNamespace>AspNetCore.DataProtection.Aws.IntegrationTests</RootNamespace>
+    <RootNamespace>AspNetCore.DataProtection.Aws.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
@@ -17,5 +17,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/AspNetCore.DataProtection.Aws.Tests/KmsXmlDecryptorTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/KmsXmlDecryptorTests.cs
@@ -13,7 +13,7 @@ using System.Threading;
 using System.Xml.Linq;
 using Xunit;
 
-namespace AspNetCore.DataProtection.Aws.IntegrationTests
+namespace AspNetCore.DataProtection.Aws.Tests
 {
     public class KmsXmlDecryptorTests : IDisposable
     {

--- a/test/AspNetCore.DataProtection.Aws.Tests/KmsXmlEncryptorTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/KmsXmlEncryptorTests.cs
@@ -12,7 +12,7 @@ using System.Threading;
 using System.Xml.Linq;
 using Xunit;
 
-namespace AspNetCore.DataProtection.Aws.IntegrationTests
+namespace AspNetCore.DataProtection.Aws.Tests
 {
     public class KmsXmlEncryptorTests : IDisposable
     {

--- a/test/AspNetCore.DataProtection.Aws.Tests/S3XmlRepositoryConfigTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/S3XmlRepositoryConfigTests.cs
@@ -4,7 +4,7 @@ using AspNetCore.DataProtection.Aws.S3;
 using System;
 using Xunit;
 
-namespace AspNetCore.DataProtection.Aws.IntegrationTests
+namespace AspNetCore.DataProtection.Aws.Tests
 {
     public class S3XmlRepositoryConfigTests
     {

--- a/test/AspNetCore.DataProtection.Aws.Tests/S3XmlRepositoryTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/S3XmlRepositoryTests.cs
@@ -13,7 +13,7 @@ using System.Threading;
 using System.Xml.Linq;
 using Xunit;
 
-namespace AspNetCore.DataProtection.Aws.IntegrationTests
+namespace AspNetCore.DataProtection.Aws.Tests
 {
     public sealed class S3XmlRespositoryTests : IDisposable
     {

--- a/test/AspNetCore.DataProtection.Aws.Tests/project.json
+++ b/test/AspNetCore.DataProtection.Aws.Tests/project.json
@@ -1,29 +1,25 @@
 {
-  "summary": "ASP.NET DataProtection Repository Integration Tests",
-  "licenseUrl": "https://opensource.org/licenses/MIT",
-  "owners": [ "hotchkj" ],
   "authors": [ "hotchkj" ],
   "version": "1.0.0-*",
+  "testRunner": "xunit",
 
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true
   },
 
-  "commands": {
-    "test": "xunit.runner.dnx -parallel all"
-  },
-
   "dependencies": {
-    "AspNetCore.DataProtection.Aws.Kms": "",
-    "AspNetCore.DataProtection.Aws.S3": "",
-    "Moq": "4.5.8",
-    "xunit": "2.1.0"
+    "AspNetCore.DataProtection.Aws.Kms": "1.0.0-*",
+    "AspNetCore.DataProtection.Aws.S3": "1.0.0-*",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "xunit": "2.2.0-beta2-build3300"
   },
 
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
-        "xunit.runner.dnx": "2.1.0-rc1-build204"
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "Moq": "4.5.8",
+        "System.Threading.Tasks": "4.0.0.0"
       }
     }
   }


### PR DESCRIPTION
Pulls in beta AWS SDK (which isn't strongly named) & limits unit testing to NET 4.5.1 until tooling matures for other platforms. Closes #1.