### PR TITLE
Switch over to IOptions since that actually seems to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ public void ConfigureServices(IServiceCollection services)
 KMS key ID _must_ be specified. If the `IAmazonKeyManagementService` interface is discoverable via Dependency Injection in `IServiceCollection`, the constructor argument of `AmazonKeyManagementServiceClient` can be omitted.
 
 _Migration Note:_ The `1.0` release of `AspNetCore.DataProtection.Aws.Kms` had `KmsXmlEncryptorConfig` take the application name as an argument, which was then used
-to populate an encryption context.
-The Data Protection application discriminator is now used to provide this value as it fulfils a similar function - that of identifying and allowing/preventing cross-talk between applications.
+to populate an encryption context. The Data Protection application discriminator is now used to provide this value as it fulfils a similar function - that of identifying and
+allowing/preventing cross-talk between applications.
 
 To ensure correct operation against existing data encrypted with `1.0`, include `SetApplicationName`, set `DiscriminatorAsContext` to `true` and
-`HashDiscriminatorContext` to `false` when setting up Data Protection for matching functionality.
+`HashDiscriminatorContext` to `false` when setting up Data Protection for matching functionality. If these values need to differ, the above can instead be
+created as a custom context with key of `KmsConstants.ApplicationEncryptionContextKey`.

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/AspNetCore.DataProtection.Aws.IntegrationTests.csproj
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/AspNetCore.DataProtection.Aws.IntegrationTests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/DirectOptions.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/DirectOptions.cs
@@ -5,9 +5,9 @@ using Microsoft.Extensions.Options;
 
 namespace AspNetCore.DataProtection.Aws.IntegrationTests
 {
-    public class DirectOptionsSnapshot<TOptions> : IOptionsSnapshot<TOptions> where TOptions : class, new()
+    public class DirectOptions<TOptions> : IOptions<TOptions> where TOptions : class, new()
     {
-        public DirectOptionsSnapshot(TOptions actualValue)
+        public DirectOptions(TOptions actualValue)
         {
             Value = actualValue;
         }

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/KmsIntegrationTests.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/KmsIntegrationTests.cs
@@ -34,12 +34,12 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             kmsClient = new AmazonKeyManagementServiceClient(RegionEndpoint.EUWest1);
             var encryptConfig = new KmsXmlEncryptorConfig(KmsTestingKey);
             dpOptions = new DataProtectionOptions { ApplicationDiscriminator = ApplicationName };
-            var encryptSnapshot = new DirectOptionsSnapshot<KmsXmlEncryptorConfig>(encryptConfig);
-            var dpSnapshot = new DirectOptionsSnapshot<DataProtectionOptions>(dpOptions);
+            var encryptSnapshot = new DirectOptions<KmsXmlEncryptorConfig>(encryptConfig);
+            var dpSnapshot = new DirectOptions<DataProtectionOptions>(dpOptions);
 
             var svcCollection = new ServiceCollection();
-            svcCollection.AddSingleton<IOptionsSnapshot<KmsXmlEncryptorConfig>>(sp => encryptSnapshot);
-            svcCollection.AddSingleton<IOptionsSnapshot<DataProtectionOptions>>(sp => dpSnapshot);
+            svcCollection.AddSingleton<IOptions<KmsXmlEncryptorConfig>>(sp => encryptSnapshot);
+            svcCollection.AddSingleton<IOptions<DataProtectionOptions>>(sp => dpSnapshot);
             svcCollection.AddSingleton(sp => kmsClient);
             svcProvider = svcCollection.BuildServiceProvider();
 

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/S3IntegrationTests.cs
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/S3IntegrationTests.cs
@@ -32,7 +32,7 @@ namespace AspNetCore.DataProtection.Aws.IntegrationTests
             s3Client = new AmazonS3Client(RegionEndpoint.EUWest1);
             // Override the default for ease of debugging. Explicitly turn on for compression tests.
             config = new S3XmlRepositoryConfig(BucketName) { ClientSideCompression = false };
-            xmlRepo = new S3XmlRepository(s3Client, new DirectOptionsSnapshot<S3XmlRepositoryConfig>(config));
+            xmlRepo = new S3XmlRepository(s3Client, new DirectOptions<S3XmlRepositoryConfig>(config));
             s3Cleanup = new CleanupS3(s3Client);
         }
 

--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/config.json
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/config.json
@@ -20,6 +20,17 @@
       "someToken"
     ],
     "discriminatorAsContext": false,
-    "hashDiscriminatorContext": false 
-  } 
+    "hashDiscriminatorContext": false
+  },
+  "s3ExplicitAwsTestCase": {
+    "bucket": "hotchkj-dataprotection-s3-integration-tests-eu-west-1",
+    "keyPrefix": "RealXmlKeyManager2/"
+  },
+  "s3ImplicitAwsTestCase": {
+    "bucket": "hotchkj-dataprotection-s3-integration-tests-eu-west-1",
+    "keyPrefix": "RealXmlKeyManager3/"
+  },
+  "kmsTestCase": {
+    "keyId": "alias/KmsIntegrationTesting"
+  }
 }

--- a/src/AspNetCore.DataProtection.Aws.Kms/AspNetCore.DataProtection.Aws.Kms.csproj
+++ b/src/AspNetCore.DataProtection.Aws.Kms/AspNetCore.DataProtection.Aws.Kms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core DataProtection encrypter &amp; decrypter for use with AWS KMS</Description>
-    <VersionPrefix>2.0.0-beta01</VersionPrefix>
+    <VersionPrefix>2.0.0-beta02</VersionPrefix>
     <Authors>hotchkj</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -14,14 +14,13 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>AspNetCore.DataProtection.Aws.Kms</PackageId>
     <PackageTags>ASP.NET;AWS;DataProtection;netcore</PackageTags>
-    <PackageReleaseNotes>
-      Supports ASP.NET Core 2.0
-      Allows configuration via ASP.NET Configuration Binding
-      Integrates with DataProtection Application Discriminator
+    <PackageReleaseNotes>Supports ASP.NET Core 2.0
+Allows configuration via ASP.NET Configuration Binding
+Integrates with DataProtection Application Discriminator
 
-      Breaking changes:
-      Requires NET Standard 2.0 and ASP.NET Core 2.0
-      Application ID no longer part of KMS Encryptor configuration - see README for migration notes
+Breaking changes:
+Requires NET Standard 2.0 and ASP.NET Core 2.0
+Application ID no longer part of KMS Encryptor configuration - see README for migration notes
     </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/hotchkj/AspNetCore.DataProtection.Aws</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>

--- a/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlDecryptor.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlDecryptor.cs
@@ -23,8 +23,8 @@ namespace AspNetCore.DataProtection.Aws.Kms
     {
         private readonly ILogger logger;
         private readonly IAmazonKeyManagementService kmsClient;
-        private readonly IOptionsSnapshot<KmsXmlEncryptorConfig> config;
-        private readonly IOptionsSnapshot<DataProtectionOptions> dpOptions;
+        private readonly IOptions<KmsXmlEncryptorConfig> config;
+        private readonly IOptions<DataProtectionOptions> dpOptions;
 
         /// <summary>
         /// Creates a <see cref="KmsXmlDecryptor"/> for decrypting ASP.NET keys with a KMS master key
@@ -38,8 +38,8 @@ namespace AspNetCore.DataProtection.Aws.Kms
         public KmsXmlDecryptor(IServiceProvider services)
         {
             kmsClient = services?.GetRequiredService<IAmazonKeyManagementService>() ?? throw new ArgumentNullException(nameof(services));
-            config = services.GetRequiredService<IOptionsSnapshot<KmsXmlEncryptorConfig>>();
-            dpOptions = services.GetRequiredService<IOptionsSnapshot<DataProtectionOptions>>();
+            config = services.GetRequiredService<IOptions<KmsXmlEncryptorConfig>>();
+            dpOptions = services.GetRequiredService<IOptions<DataProtectionOptions>>();
             logger = services.GetService<ILoggerFactory>()?.CreateLogger<KmsXmlDecryptor>();
         }
 

--- a/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlEncryptor.cs
+++ b/src/AspNetCore.DataProtection.Aws.Kms/KmsXmlEncryptor.cs
@@ -22,8 +22,8 @@ namespace AspNetCore.DataProtection.Aws.Kms
     {
         private readonly ILogger logger;
         private readonly IAmazonKeyManagementService kmsClient;
-        private readonly IOptionsSnapshot<KmsXmlEncryptorConfig> config;
-        private readonly IOptionsSnapshot<DataProtectionOptions> dpOptions;
+        private readonly IOptions<KmsXmlEncryptorConfig> config;
+        private readonly IOptions<DataProtectionOptions> dpOptions;
 
         // ReSharper disable once InheritdocConsiderUsage
         /// <summary>
@@ -32,7 +32,7 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// <param name="kmsClient">The KMS client</param>
         /// <param name="config">The configuration object specifying which key data in KMS to use</param>
         /// <param name="dpOptions">Main data protection options</param>
-        public KmsXmlEncryptor(IAmazonKeyManagementService kmsClient, IOptionsSnapshot<KmsXmlEncryptorConfig> config, IOptionsSnapshot<DataProtectionOptions> dpOptions)
+        public KmsXmlEncryptor(IAmazonKeyManagementService kmsClient, IOptions<KmsXmlEncryptorConfig> config, IOptions<DataProtectionOptions> dpOptions)
             : this(kmsClient, config, dpOptions, null)
         {
         }
@@ -45,8 +45,8 @@ namespace AspNetCore.DataProtection.Aws.Kms
         /// <param name="dpOptions">Main data protection options</param>
         /// <param name="loggerFactory">An optional <see cref="ILoggerFactory"/> to provide logging infrastructure.</param>
         public KmsXmlEncryptor(IAmazonKeyManagementService kmsClient,
-                               IOptionsSnapshot<KmsXmlEncryptorConfig> config,
-                               IOptionsSnapshot<DataProtectionOptions> dpOptions,
+                               IOptions<KmsXmlEncryptorConfig> config,
+                               IOptions<DataProtectionOptions> dpOptions,
                                ILoggerFactory loggerFactory)
         {
             this.kmsClient = kmsClient ?? throw new ArgumentNullException(nameof(kmsClient));

--- a/src/AspNetCore.DataProtection.Aws.S3/AspNetCore.DataProtection.Aws.S3.csproj
+++ b/src/AspNetCore.DataProtection.Aws.S3/AspNetCore.DataProtection.Aws.S3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core DataProtection repository for use with AWS S3</Description>
-    <VersionPrefix>2.0.0-beta01</VersionPrefix>
+    <VersionPrefix>2.0.0-beta02</VersionPrefix>
     <Authors>hotchkj</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -14,12 +14,11 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>AspNetCore.DataProtection.Aws.S3</PackageId>
     <PackageTags>ASP.NET;AWS;DataProtection;netcore</PackageTags>
-    <PackageReleaseNotes>
-      Supports ASP.NET Core 2.0
-      Allows configuration via ASP.NET Configuration Binding
+    <PackageReleaseNotes>Supports ASP.NET Core 2.0
+Allows configuration via ASP.NET Configuration Binding
 
-      Breaking changes:
-      Requires NET Standard 2.0 and ASP.NET Core 2.0
+Breaking changes:
+Requires NET Standard 2.0 and ASP.NET Core 2.0
     </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/hotchkj/AspNetCore.DataProtection.Aws</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>

--- a/src/AspNetCore.DataProtection.Aws.S3/DataProtectionBuilderExtensions.cs
+++ b/src/AspNetCore.DataProtection.Aws.S3/DataProtectionBuilderExtensions.cs
@@ -118,17 +118,18 @@ namespace AspNetCore.DataProtection.Aws.S3
         private static IDataProtectionBuilder PersistKeysToAwsS3Raw(this IDataProtectionBuilder builder, IAmazonS3 s3Client, IS3XmlRepositoryConfig config)
         {
             builder.Services.AddSingleton<IConfigureOptions<S3XmlRepositoryConfig>>(new DirectConfigure(config));
-            return builder.PersistKeysToAwsS3Impl(s3Client, sp => sp.GetRequiredService<IOptionsSnapshot<S3XmlRepositoryConfig>>());
+            return builder.PersistKeysToAwsS3Impl(s3Client, sp => sp.GetRequiredService<IOptions<S3XmlRepositoryConfig>>());
         }
 
         private static IDataProtectionBuilder PersistKeysToAwsS3Config(this IDataProtectionBuilder builder, IAmazonS3 s3Client, IConfiguration config)
         {
             builder.Services.Configure<S3XmlRepositoryConfig>(config);
-            return builder.PersistKeysToAwsS3Impl(s3Client, sp => sp.GetRequiredService<IOptionsSnapshot<S3XmlRepositoryConfig>>());
+            return builder.PersistKeysToAwsS3Impl(s3Client, sp => sp.GetRequiredService<IOptions<S3XmlRepositoryConfig>>());
         }
 
-        private static IDataProtectionBuilder PersistKeysToAwsS3Impl(this IDataProtectionBuilder builder, IAmazonS3 s3Client, Func<IServiceProvider, IOptionsSnapshot<S3XmlRepositoryConfig>> getOptions)
+        private static IDataProtectionBuilder PersistKeysToAwsS3Impl(this IDataProtectionBuilder builder, IAmazonS3 s3Client, Func<IServiceProvider, IOptions<S3XmlRepositoryConfig>> getOptions)
         {
+            builder.Services.AddOptions();
             builder.Services.TryAddSingleton<IMockingWrapper, MockingWrapper>();
             builder.Services.AddSingleton<IConfigureOptions<KeyManagementOptions>>(serviceProvider =>
                                                                                    {

--- a/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepository.cs
+++ b/src/AspNetCore.DataProtection.Aws.S3/S3XmlRepository.cs
@@ -28,7 +28,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         private readonly ILogger logger;
         private readonly IMockingWrapper mockWrapper;
         private readonly IAmazonS3 s3Client;
-        private readonly IOptionsSnapshot<S3XmlRepositoryConfig> config;
+        private readonly IOptions<S3XmlRepositoryConfig> config;
 
         /// <summary>
         /// S3 metadata header for the friendly name of the stored XML element.
@@ -41,7 +41,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         /// </summary>
         /// <param name="s3Client">The S3 client.</param>
         /// <param name="config">The configuration object specifying how to write to S3.</param>
-        public S3XmlRepository(IAmazonS3 s3Client, IOptionsSnapshot<S3XmlRepositoryConfig> config)
+        public S3XmlRepository(IAmazonS3 s3Client, IOptions<S3XmlRepositoryConfig> config)
             : this(s3Client, config, null)
         {
         }
@@ -53,7 +53,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         /// <param name="s3Client">The S3 client.</param>
         /// <param name="config">The configuration object specifying how to write to S3.</param>
         /// <param name="loggerFactory">An optional <see cref="ILoggerFactory"/> to provide logging infrastructure.</param>
-        public S3XmlRepository(IAmazonS3 s3Client, IOptionsSnapshot<S3XmlRepositoryConfig> config, ILoggerFactory loggerFactory)
+        public S3XmlRepository(IAmazonS3 s3Client, IOptions<S3XmlRepositoryConfig> config, ILoggerFactory loggerFactory)
             : this(s3Client, config, loggerFactory, new MockingWrapper())
         {
         }
@@ -65,7 +65,7 @@ namespace AspNetCore.DataProtection.Aws.S3
         /// <param name="config">The configuration object specifying how to write to S3.</param>
         /// <param name="loggerFactory">An optional <see cref="ILoggerFactory"/> to provide logging infrastructure.</param>
         /// <param name="mockWrapper">Wrapper object to ensure unit testing is feasible.</param>
-        public S3XmlRepository(IAmazonS3 s3Client, IOptionsSnapshot<S3XmlRepositoryConfig> config, ILoggerFactory loggerFactory, IMockingWrapper mockWrapper)
+        public S3XmlRepository(IAmazonS3 s3Client, IOptions<S3XmlRepositoryConfig> config, ILoggerFactory loggerFactory, IMockingWrapper mockWrapper)
         {
             this.s3Client = s3Client ?? throw new ArgumentNullException(nameof(s3Client));
             this.config = config ?? throw new ArgumentNullException(nameof(config));

--- a/test/AspNetCore.DataProtection.Aws.Tests/AspNetCore.DataProtection.Aws.Tests.csproj
+++ b/test/AspNetCore.DataProtection.Aws.Tests/AspNetCore.DataProtection.Aws.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/AspNetCore.DataProtection.Aws.Tests/KmsDataProtectionBuilderExtensionsTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/KmsDataProtectionBuilderExtensionsTests.cs
@@ -24,8 +24,8 @@ namespace AspNetCore.DataProtection.Aws.Tests
         private readonly Mock<IAmazonKeyManagementService> client;
         private readonly Mock<IServiceProvider> provider;
         private readonly Mock<ILoggerFactory> loggerFactory;
-        private readonly Mock<IOptionsSnapshot<KmsXmlEncryptorConfig>> snapshot;
-        private readonly Mock<IOptionsSnapshot<DataProtectionOptions>> dpSnapshot;
+        private readonly Mock<IOptions<KmsXmlEncryptorConfig>> snapshot;
+        private readonly Mock<IOptions<DataProtectionOptions>> dpSnapshot;
         private readonly MockRepository repository;
 
         public KmsDataProtectionBuilderExtensionsTests()
@@ -36,8 +36,8 @@ namespace AspNetCore.DataProtection.Aws.Tests
             svcCollection = repository.Create<IServiceCollection>();
             provider = repository.Create<IServiceProvider>();
             loggerFactory = repository.Create<ILoggerFactory>();
-            snapshot = repository.Create<IOptionsSnapshot<KmsXmlEncryptorConfig>>();
-            dpSnapshot = repository.Create<IOptionsSnapshot<DataProtectionOptions>>();
+            snapshot = repository.Create<IOptions<KmsXmlEncryptorConfig>>();
+            dpSnapshot = repository.Create<IOptions<DataProtectionOptions>>();
         }
 
         public void Dispose()
@@ -71,7 +71,6 @@ namespace AspNetCore.DataProtection.Aws.Tests
                 builder.Object.ProtectKeysWithAwsKms(config);
             }
 
-            Assert.Equal(withClient ? 5 : 4, services.Count);
             Assert.Equal(withClient ? 1 : 0, services.Count(x => x.ServiceType == typeof(IAmazonKeyManagementService)));
 
             // IConfigureOptions is designed & expected to be present multiple times, so expect two after two calls
@@ -93,8 +92,8 @@ namespace AspNetCore.DataProtection.Aws.Tests
             ((IConfigureOptions<KmsXmlEncryptorConfig>)configureObject).Configure(optionsObject);
 
             provider.Setup(x => x.GetService(typeof(ILoggerFactory))).Returns(loggerFactory.Object);
-            provider.Setup(x => x.GetService(typeof(IOptionsSnapshot<KmsXmlEncryptorConfig>))).Returns(snapshot.Object);
-            provider.Setup(x => x.GetService(typeof(IOptionsSnapshot<DataProtectionOptions>))).Returns(dpSnapshot.Object);
+            provider.Setup(x => x.GetService(typeof(IOptions<KmsXmlEncryptorConfig>))).Returns(snapshot.Object);
+            provider.Setup(x => x.GetService(typeof(IOptions<DataProtectionOptions>))).Returns(dpSnapshot.Object);
             loggerFactory.Setup(x => x.CreateLogger(typeof(KmsXmlEncryptor).FullName)).Returns(repository.Create<ILogger<KmsXmlEncryptor>>().Object);
             snapshot.Setup(x => x.Value).Returns(optionsObject);
             var dbOptions = new DataProtectionOptions();
@@ -136,7 +135,6 @@ namespace AspNetCore.DataProtection.Aws.Tests
                 builder.Object.ProtectKeysWithAwsKms(configMock.Object);
             }
 
-            Assert.Equal(withClient ? 7 : 6, services.Count); // 2 extra from configuration monitoring
             Assert.Equal(withClient ? 1 : 0, services.Count(x => x.ServiceType == typeof(IAmazonKeyManagementService)));
 
             // IConfigureOptions is designed & expected to be present multiple times, so expect two after two calls
@@ -158,8 +156,8 @@ namespace AspNetCore.DataProtection.Aws.Tests
             ((IConfigureOptions<KmsXmlEncryptorConfig>)configureObject).Configure(optionsObject);
 
             provider.Setup(x => x.GetService(typeof(ILoggerFactory))).Returns(loggerFactory.Object);
-            provider.Setup(x => x.GetService(typeof(IOptionsSnapshot<KmsXmlEncryptorConfig>))).Returns(snapshot.Object);
-            provider.Setup(x => x.GetService(typeof(IOptionsSnapshot<DataProtectionOptions>))).Returns(dpSnapshot.Object);
+            provider.Setup(x => x.GetService(typeof(IOptions<KmsXmlEncryptorConfig>))).Returns(snapshot.Object);
+            provider.Setup(x => x.GetService(typeof(IOptions<DataProtectionOptions>))).Returns(dpSnapshot.Object);
             loggerFactory.Setup(x => x.CreateLogger(typeof(KmsXmlEncryptor).FullName)).Returns(repository.Create<ILogger<KmsXmlEncryptor>>().Object);
             snapshot.Setup(x => x.Value).Returns(optionsObject);
             var dbOptions = new DataProtectionOptions();

--- a/test/AspNetCore.DataProtection.Aws.Tests/KmsXmlDecryptorTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/KmsXmlDecryptorTests.cs
@@ -22,8 +22,8 @@ namespace AspNetCore.DataProtection.Aws.Tests
         private readonly KmsXmlDecryptor decryptor;
         private readonly MockRepository repository;
         private readonly Mock<IAmazonKeyManagementService> kmsClient;
-        private readonly Mock<IOptionsSnapshot<KmsXmlEncryptorConfig>> encryptConfig;
-        private readonly Mock<IOptionsSnapshot<DataProtectionOptions>> dpOptions;
+        private readonly Mock<IOptions<KmsXmlEncryptorConfig>> encryptConfig;
+        private readonly Mock<IOptions<DataProtectionOptions>> dpOptions;
         private const string KeyId = "keyId";
         private const string ElementName = "name";
         private readonly Dictionary<string, string> encryptionContext = new Dictionary<string, string>();
@@ -33,13 +33,13 @@ namespace AspNetCore.DataProtection.Aws.Tests
         {
             repository = new MockRepository(MockBehavior.Strict);
             kmsClient = repository.Create<IAmazonKeyManagementService>();
-            encryptConfig = repository.Create<IOptionsSnapshot<KmsXmlEncryptorConfig>>();
-            dpOptions = repository.Create<IOptionsSnapshot<DataProtectionOptions>>();
+            encryptConfig = repository.Create<IOptions<KmsXmlEncryptorConfig>>();
+            dpOptions = repository.Create<IOptions<DataProtectionOptions>>();
             var serviceProvider = repository.Create<IServiceProvider>();
 
-            serviceProvider.Setup(x => x.GetService(typeof(IOptionsSnapshot<KmsXmlEncryptorConfig>)))
+            serviceProvider.Setup(x => x.GetService(typeof(IOptions<KmsXmlEncryptorConfig>)))
                            .Returns(encryptConfig.Object);
-            serviceProvider.Setup(x => x.GetService(typeof(IOptionsSnapshot<DataProtectionOptions>)))
+            serviceProvider.Setup(x => x.GetService(typeof(IOptions<DataProtectionOptions>)))
                            .Returns(dpOptions.Object);
             serviceProvider.Setup(x => x.GetService(typeof(IAmazonKeyManagementService)))
                            .Returns(kmsClient.Object);

--- a/test/AspNetCore.DataProtection.Aws.Tests/KmsXmlEncryptorTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/KmsXmlEncryptorTests.cs
@@ -21,8 +21,8 @@ namespace AspNetCore.DataProtection.Aws.Tests
         private readonly KmsXmlEncryptor encryptor;
         private readonly MockRepository repository;
         private readonly Mock<IAmazonKeyManagementService> kmsClient;
-        private readonly Mock<IOptionsSnapshot<KmsXmlEncryptorConfig>> encryptConfig;
-        private readonly Mock<IOptionsSnapshot<DataProtectionOptions>> dpOptions;
+        private readonly Mock<IOptions<KmsXmlEncryptorConfig>> encryptConfig;
+        private readonly Mock<IOptions<DataProtectionOptions>> dpOptions;
         private const string KeyId = "keyId";
         private const string ElementName = "name";
         private readonly Dictionary<string, string> encryptionContext = new Dictionary<string, string>();
@@ -32,8 +32,8 @@ namespace AspNetCore.DataProtection.Aws.Tests
         {
             repository = new MockRepository(MockBehavior.Strict);
             kmsClient = repository.Create<IAmazonKeyManagementService>();
-            encryptConfig = repository.Create<IOptionsSnapshot<KmsXmlEncryptorConfig>>();
-            dpOptions = repository.Create<IOptionsSnapshot<DataProtectionOptions>>();
+            encryptConfig = repository.Create<IOptions<KmsXmlEncryptorConfig>>();
+            dpOptions = repository.Create<IOptions<DataProtectionOptions>>();
 
             encryptor = new KmsXmlEncryptor(kmsClient.Object, encryptConfig.Object, dpOptions.Object);
         }

--- a/test/AspNetCore.DataProtection.Aws.Tests/S3DataProtectionBuilderExtensionsTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/S3DataProtectionBuilderExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace AspNetCore.DataProtection.Aws.Tests
         private readonly Mock<IAmazonS3> client;
         private readonly Mock<IServiceProvider> provider;
         private readonly Mock<ILoggerFactory> loggerFactory;
-        private readonly Mock<IOptionsSnapshot<S3XmlRepositoryConfig>> snapshot;
+        private readonly Mock<IOptions<S3XmlRepositoryConfig>> snapshot;
         private readonly MockRepository repository;
 
         public S3DataProtectionBuilderExtensionsTests()
@@ -36,7 +36,7 @@ namespace AspNetCore.DataProtection.Aws.Tests
             svcCollection = repository.Create<IServiceCollection>();
             provider = repository.Create<IServiceProvider>();
             loggerFactory = repository.Create<ILoggerFactory>();
-            snapshot = repository.Create<IOptionsSnapshot<S3XmlRepositoryConfig>>();
+            snapshot = repository.Create<IOptions<S3XmlRepositoryConfig>>();
         }
 
         public void Dispose()
@@ -71,7 +71,6 @@ namespace AspNetCore.DataProtection.Aws.Tests
                 provider.Setup(x => x.GetService(typeof(IAmazonS3))).Returns(client.Object);
             }
 
-            Assert.Equal(5, services.Count);
             Assert.Equal(1, services.Count(x => x.ServiceType == typeof(IMockingWrapper)));
 
             // IConfigureOptions is designed & expected to be present multiple times, so expect two after two calls
@@ -88,7 +87,7 @@ namespace AspNetCore.DataProtection.Aws.Tests
             ((IConfigureOptions<S3XmlRepositoryConfig>)configureObject).Configure(optionsObject);
 
             provider.Setup(x => x.GetService(typeof(ILoggerFactory))).Returns(loggerFactory.Object);
-            provider.Setup(x => x.GetService(typeof(IOptionsSnapshot<S3XmlRepositoryConfig>))).Returns(snapshot.Object);
+            provider.Setup(x => x.GetService(typeof(IOptions<S3XmlRepositoryConfig>))).Returns(snapshot.Object);
             loggerFactory.Setup(x => x.CreateLogger(typeof(S3XmlRepository).FullName)).Returns(repository.Create<ILogger<S3XmlRepository>>().Object);
             snapshot.Setup(x => x.Value).Returns(optionsObject);
 
@@ -129,7 +128,6 @@ namespace AspNetCore.DataProtection.Aws.Tests
                 provider.Setup(x => x.GetService(typeof(IAmazonS3))).Returns(client.Object);
             }
 
-            Assert.Equal(7, services.Count); // 2 extra from configuration monitoring
             Assert.Equal(1, services.Count(x => x.ServiceType == typeof(IMockingWrapper)));
 
             // IConfigureOptions is designed & expected to be present multiple times, so expect two after two calls
@@ -146,7 +144,7 @@ namespace AspNetCore.DataProtection.Aws.Tests
             ((IConfigureOptions<S3XmlRepositoryConfig>)configureObject).Configure(optionsObject);
 
             provider.Setup(x => x.GetService(typeof(ILoggerFactory))).Returns(loggerFactory.Object);
-            provider.Setup(x => x.GetService(typeof(IOptionsSnapshot<S3XmlRepositoryConfig>))).Returns(snapshot.Object);
+            provider.Setup(x => x.GetService(typeof(IOptions<S3XmlRepositoryConfig>))).Returns(snapshot.Object);
             loggerFactory.Setup(x => x.CreateLogger(typeof(S3XmlRepository).FullName)).Returns(repository.Create<ILogger<S3XmlRepository>>().Object);
             snapshot.Setup(x => x.Value).Returns(optionsObject);
 

--- a/test/AspNetCore.DataProtection.Aws.Tests/S3XmlRepositoryTests.cs
+++ b/test/AspNetCore.DataProtection.Aws.Tests/S3XmlRepositoryTests.cs
@@ -22,7 +22,7 @@ namespace AspNetCore.DataProtection.Aws.Tests
         private readonly S3XmlRepository xmlRepository;
         private readonly MockRepository repository;
         private readonly Mock<IAmazonS3> s3Client;
-        private readonly Mock<IOptionsSnapshot<S3XmlRepositoryConfig>> config;
+        private readonly Mock<IOptions<S3XmlRepositoryConfig>> config;
         private readonly Mock<IMockingWrapper> mockingWrapper;
         private const string ElementName = "name";
         private const string ElementContent = "test";
@@ -36,7 +36,7 @@ namespace AspNetCore.DataProtection.Aws.Tests
         {
             repository = new MockRepository(MockBehavior.Strict);
             s3Client = repository.Create<IAmazonS3>();
-            config = repository.Create<IOptionsSnapshot<S3XmlRepositoryConfig>>();
+            config = repository.Create<IOptions<S3XmlRepositoryConfig>>();
             mockingWrapper = repository.Create<IMockingWrapper>();
             xmlRepository = new S3XmlRepository(s3Client.Object, config.Object, null, mockingWrapper.Object);
         }


### PR DESCRIPTION
More work on #21, since the DI behaviour with `IOptionsSnapshot` isn't operating as one might expect - reloading configuration on the fly will have to be revisited

Sadly all the tests I wrote passed, and only the full app manually run failed, so I've raised #25 to look at automating this (whether inside xunit or separately)