### PR TITLE
Make semver restrictions less restrictive

### DIFF
--- a/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/AspNetCore.DataProtection.Aws.IntegrationTests.csproj
+++ b/integrate/AspNetCore.DataProtection.Aws.IntegrationTests/AspNetCore.DataProtection.Aws.IntegrationTests.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Moq" Version="4.8.2" />

--- a/src/AspNetCore.DataProtection.Aws.Kms/AspNetCore.DataProtection.Aws.Kms.csproj
+++ b/src/AspNetCore.DataProtection.Aws.Kms/AspNetCore.DataProtection.Aws.Kms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core DataProtection encrypter &amp; decrypter for use with AWS KMS</Description>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <Authors>hotchkj</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>AspNetCore.DataProtection.Aws.Kms</AssemblyName>
@@ -16,7 +16,7 @@
 Allows configuration via ASP.NET Configuration Binding
 Integrates with DataProtection Application Discriminator
 PDBs now embedded &amp; source linked
-Semantic versioning included in dependencies
+Semantic versioning included in dependencies, restricted to minimums only
 
 Breaking changes:
 Requires NET Standard 2.0 and ASP.NET Core 2.0
@@ -48,9 +48,9 @@ Application ID no longer part of KMS Encryptor configuration - see README for mi
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.2.1" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.0" PrivateAssets="all" />
-    <PackageReference Include="AWSSDK.KeyManagementService" Version="[3.3.5.2, 4.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="[2.0.2, 3.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.0.2, 3.0.0)" />
+    <PackageReference Include="AWSSDK.KeyManagementService" Version="[3.3.5.2,)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="[2.0.2,)" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.0.2,)" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNetCore.DataProtection.Aws.S3/AspNetCore.DataProtection.Aws.S3.csproj
+++ b/src/AspNetCore.DataProtection.Aws.S3/AspNetCore.DataProtection.Aws.S3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core DataProtection repository for use with AWS S3</Description>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <Authors>hotchkj</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>AspNetCore.DataProtection.Aws.S3</AssemblyName>
@@ -15,7 +15,7 @@
     <PackageReleaseNotes>Supports ASP.NET Core 2.0
 Allows configuration via ASP.NET Configuration Binding
 PDBs now embedded &amp; source linked
-Semantic versioning included in dependencies
+Semantic versioning included in dependencies, restricted to minimums only
 
 Breaking changes:
 Requires NET Standard 2.0 and ASP.NET Core 2.0
@@ -46,9 +46,9 @@ Requires NET Standard 2.0 and ASP.NET Core 2.0
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.2.1" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.0" PrivateAssets="all" />
-    <PackageReference Include="AWSSDK.S3" Version="[3.3.17.2, 4.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="[2.0.2, 3.0.0)" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.0.2, 3.0.0)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.3.17.2,)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="[2.0.2,)" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.0.2,)" />
   </ItemGroup>
 
 </Project>

--- a/test/AspNetCore.DataProtection.Aws.Tests/AspNetCore.DataProtection.Aws.Tests.csproj
+++ b/test/AspNetCore.DataProtection.Aws.Tests/AspNetCore.DataProtection.Aws.Tests.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
Following the MS pattern of restricting the minimum, but the maximum is up to you. If you want to take breaking changes and they happen to work with binding redirects, so be it.